### PR TITLE
fix(contented-preview): add missing deps that preview need

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13931,6 +13931,7 @@
         "@heroicons/react": "^1.0.6",
         "@tailwindcss/line-clamp": "^0.4.0",
         "@tailwindcss/typography": "^0.5.3",
+        "@types/node": "16.11.43",
         "@types/react": "18.0.15",
         "@types/react-dom": "18.0.6",
         "autoprefixer": "^10.4.7",
@@ -13944,7 +13945,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-schemaorg": "^2.0.0",
-        "tailwindcss": "^3.1.5"
+        "tailwindcss": "^3.1.5",
+        "typescript": "4.7.4"
       },
       "bin": {
         "contented": "cli.js"
@@ -14090,7 +14092,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "husky": "^8.0.1",
-        "lerna": "*",
+        "lerna": "^5.1.8",
         "lint-staged": "^13.0.3",
         "prettier": "2.7.1",
         "prettier-plugin-tailwindcss": "^0.1.12",
@@ -14211,6 +14213,7 @@
             "@heroicons/react": "^1.0.6",
             "@tailwindcss/line-clamp": "^0.4.0",
             "@tailwindcss/typography": "^0.5.3",
+            "@types/node": "16.11.43",
             "@types/react": "18.0.15",
             "@types/react-dom": "18.0.6",
             "autoprefixer": "^10.4.7",
@@ -14224,7 +14227,8 @@
             "react": "18.2.0",
             "react-dom": "18.2.0",
             "react-schemaorg": "^2.0.0",
-            "tailwindcss": "^3.1.5"
+            "tailwindcss": "^3.1.5",
+            "typescript": "4.7.4"
           }
         },
         "@birthdayresearch/contented-processor": {
@@ -24272,6 +24276,7 @@
         "@heroicons/react": "^1.0.6",
         "@tailwindcss/line-clamp": "^0.4.0",
         "@tailwindcss/typography": "^0.5.3",
+        "@types/node": "16.11.43",
         "@types/react": "18.0.15",
         "@types/react-dom": "18.0.6",
         "autoprefixer": "^10.4.7",
@@ -24285,7 +24290,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-schemaorg": "^2.0.0",
-        "tailwindcss": "^3.1.5"
+        "tailwindcss": "^3.1.5",
+        "typescript": "4.7.4"
       }
     },
     "@birthdayresearch/contented-processor": {

--- a/packages/contented-preview/package.json
+++ b/packages/contented-preview/package.json
@@ -11,6 +11,7 @@
     "build": "contentlayer build"
   },
   "dependencies": {
+    "@types/node": "16.11.43",
     "@headlessui/react": "^1.6.6",
     "@heroicons/react": "^1.0.6",
     "@tailwindcss/line-clamp": "^0.4.0",
@@ -28,6 +29,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-schemaorg": "^2.0.0",
-    "tailwindcss": "^3.1.5"
+    "tailwindcss": "^3.1.5",
+    "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

All dependencies that are required need to be present in `package.json`, since hoisting isn't guarantee if the consumer don't use what we use.