### PR TITLE
chore(lint): add more ignore rules for linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,8 @@
     "**/*.config.js",
     "contented.js",
     "**/contented-processor/**/*.d.ts",
-    "**/contented-processor/**/*.js"
+    "**/contented-processor/**/*.js",
+    "**/out"
   ],
   "rules": {
     "class-methods-use-this": "off",

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,10 @@
 .husky
 .idea
 .next
+out
+*.d.ts
+*.d.ts.map
+*.js
+*.js.map
+tsconfig.tsbuildinfo
 package-lock.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Ignore `out` and `*.js` outputs.
