### PR TITLE
chore(contented-preview): simplify the contented cli

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
     "contented.js",
     "**/contented-processor/**/*.d.ts",
     "**/contented-processor/**/*.js",
-    "**/out"
+    "**/.contented",
+    "**/dist"
   ],
   "rules": {
     "class-methods-use-this": "off",

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,5 @@ out
 *.js.map
 tsconfig.tsbuildinfo
 package-lock.json
+.contented
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -13872,6 +13872,7 @@
       "name": "@birthdayresearch/contented-preview",
       "version": "0.0.0",
       "dependencies": {
+        "@birthdayresearch/contented-processor": "0.0.0",
         "@headlessui/react": "^1.6.6",
         "@heroicons/react": "^1.0.6",
         "@tailwindcss/line-clamp": "^0.4.0",
@@ -14149,6 +14150,7 @@
         "@birthdayresearch/contented-preview": {
           "version": "file:packages/contented-preview",
           "requires": {
+            "@birthdayresearch/contented-processor": "0.0.0",
             "@headlessui/react": "^1.6.6",
             "@heroicons/react": "^1.0.6",
             "@tailwindcss/line-clamp": "^0.4.0",
@@ -24161,6 +24163,7 @@
     "@birthdayresearch/contented-preview": {
       "version": "file:packages/contented-preview",
       "requires": {
+        "@birthdayresearch/contented-processor": "0.0.0",
         "@headlessui/react": "^1.6.6",
         "@heroicons/react": "^1.0.6",
         "@tailwindcss/line-clamp": "^0.4.0",

--- a/packages/contented-example/.gitignore
+++ b/packages/contented-example/.gitignore
@@ -1,8 +1,5 @@
 # Publish this into npm registry
 dist
 
-# Publish this into Vercel or Netlify (with https://www.npmjs.com/package/@netlify/plugin-nextjs)
-.next
-
-# Otherwise publish this into any static site capable website
-out
+# Preview website
+.contented

--- a/packages/contented-preview/cli.js
+++ b/packages/contented-preview/cli.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-const { symlinkSync, existsSync, rmSync, cpSync } = require('node:fs');
+const { cpSync } = require('node:fs');
 const { spawnSync } = require('node:child_process');
 const commandLineArgs = require('command-line-args');
 
@@ -8,34 +8,19 @@ const { command } = commandLineArgs(mainDefinitions, {
   stopAtFirstUnknown: true,
 });
 
-const path = `${__dirname}/contented.js`;
-const target = `${process.cwd()}/contented.js`;
-if (existsSync(path)) {
-  rmSync(path);
-}
-symlinkSync(target, path, 'file');
+const contentedDir = `${process.cwd()}/.contented`;
 
-spawnSync(`npm`, ['run', command, '--prefix', __dirname], {
+cpSync(`${__dirname}`, contentedDir, {
+  recursive: true,
+});
+
+spawnSync(`npm`, ['run', command, '--prefix', contentedDir], {
   stdio: 'inherit',
-  cwd: __dirname,
-  env: {
-    ...process.env,
-    CONTENTED_CWD: process.cwd(),
-  },
+  cwd: contentedDir,
 });
 
 if (command === 'build') {
-  cpSync(`${__dirname}/.contentlayer/generated`, `${process.cwd()}/dist`, {
-    recursive: true,
-  });
-}
-
-if (command === 'generate') {
-  cpSync(`${__dirname}/.next`, `${process.cwd()}/.next`, {
-    recursive: true,
-  });
-
-  cpSync(`${__dirname}/out`, `${process.cwd()}/out`, {
+  cpSync(`${contentedDir}/.contentlayer/generated`, `${process.cwd()}/dist`, {
     recursive: true,
   });
 }

--- a/packages/contented-preview/contentlayer.config.js
+++ b/packages/contented-preview/contentlayer.config.js
@@ -1,13 +1,15 @@
 import { join } from 'node:path';
 import { makeSource } from 'contentlayer/source-files';
-import contented from './contented';
+
+// noinspection JSFileReferences
+import contented from '../contented';
 
 async function makeConfig() {
   return makeSource({
-    contentDirPath: join(process.env.CONTENTED_CWD, contented.rootDir),
+    contentDirPath: join('../', contented.rootDir),
     markdown: await contented.unified(),
     documentTypes: contented.types,
-    contentDirExclude: ['dist', '.next', 'out'],
+    contentDirExclude: ['dist', '.next', 'out', '.contented'],
     onUnknownDocuments: 'skip-ignore',
     disableImportAliasWarning: true,
   });

--- a/packages/contented-preview/next-sitemap.config.js
+++ b/packages/contented-preview/next-sitemap.config.js
@@ -1,5 +1,5 @@
-const { join } = require('node:path');
-const preview = require(join(process.env.CONTENTED_CWD, 'package.json'))?.['contented'];
+// noinspection JSFileReferences
+const preview = require('../package.json')?.['contented'];
 
 module.exports = {
   siteUrl: preview?.url ?? process.env.SITE_URL,

--- a/packages/contented-preview/next.config.js
+++ b/packages/contented-preview/next.config.js
@@ -1,8 +1,8 @@
-const { join } = require('node:path');
-const { createContentlayerPlugin } = require('next-contentlayer');
+const { withContentlayer } = require('next-contentlayer');
 
+// noinspection JSFileReferences
 /** @type {ContentedPreview} */
-const preview = require(join(process.env.CONTENTED_CWD, 'package.json'))?.['contented'];
+const preview = require('../package.json')?.['contented'];
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -18,9 +18,5 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
 };
-
-const withContentlayer = createContentlayerPlugin({
-  configPath: join(__dirname, 'contentlayer.config.js'),
-});
 
 module.exports = withContentlayer(nextConfig);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

By copying into $cwd/.contented and start it from there, instead of manipulating `cwd` and symbolic linking files.
