### PR TITLE
feat(contented-processor): add directive processing, with ssg auto-styling admonitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14260,7 +14260,7 @@
             "rehype-parse": "^8.0.4",
             "rehype-slug": "^5.0.1",
             "remark-directive": "^2.0.1",
-            "remark-directive-rehype": "*",
+            "remark-directive-rehype": "^0.4.0",
             "remark-gfm": "^3.0.1",
             "shiki": "^0.10.1",
             "unified": "^10.1.2"
@@ -24330,7 +24330,7 @@
         "rehype-parse": "^8.0.4",
         "rehype-slug": "^5.0.1",
         "remark-directive": "^2.0.1",
-        "remark-directive-rehype": "*",
+        "remark-directive-rehype": "^0.4.0",
         "remark-gfm": "^3.0.1",
         "shiki": "^0.10.1",
         "unified": "^10.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8375,6 +8375,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-2.2.1.tgz",
+      "integrity": "sha512-yZRRuaulzc6bM4IOyZfkOrVs+9Sf1BC+rldRXJyl/Ej6S/6ewQQ9jt75HvEoqZZ4m9ealVTHiS4MP2GRUE7INA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.1.tgz",
@@ -8919,6 +8936,24 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-2.1.1.tgz",
+      "integrity": "sha512-+7MYZ3a10cpPrQRg3530srFMSBx0EL7gQaJ3ekguOQFSlJHLikW15AphBmNxvCNdRSWTX1R8RepzjKQra8INQw==",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "parse-entities": "^4.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-frontmatter": {
@@ -12014,6 +12049,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-directive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-2.0.1.tgz",
+      "integrity": "sha512-oosbsUAkU/qmUE78anLaJePnPis4ihsE7Agp0T/oqTzvTea8pOiaYEtfInU/+xMOVTS9PN5AhGOiaIVe4GD8gw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-directive": "^2.0.0",
+        "micromark-extension-directive": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive-rehype": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/remark-directive-rehype/-/remark-directive-rehype-0.4.0.tgz",
+      "integrity": "sha512-RrcjHXJ566myykjUIx3UNFxrAfHxFJeGK1jF8uqrxq5sBxO8YRBkg/W4640wqX5NCXny7khrqH23Dag8kYCl5A==",
+      "dependencies": {
+        "hastscript": "^7.0.2",
+        "unist-util-map": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/remark-frontmatter": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
@@ -13266,6 +13328,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-map": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.1.1.tgz",
+      "integrity": "sha512-n36sjBn4ibPtAzrFweyT4FOcCI/UdzboaEcsZvwoAyD/gVw5B3OLlMBySePMO6r+uzjxQEyRll2akfVaT4SHhw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-modify-children": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-3.0.0.tgz",
@@ -13908,6 +13982,8 @@
         "rehype-autolink-headings": "^6.1.1",
         "rehype-parse": "^8.0.4",
         "rehype-slug": "^5.0.1",
+        "remark-directive": "^2.0.1",
+        "remark-directive-rehype": "^0.4.0",
         "remark-gfm": "^3.0.1",
         "shiki": "^0.10.1",
         "unified": "^10.1.2"
@@ -14183,6 +14259,8 @@
             "rehype-autolink-headings": "^6.1.1",
             "rehype-parse": "^8.0.4",
             "rehype-slug": "^5.0.1",
+            "remark-directive": "^2.0.1",
+            "remark-directive-rehype": "*",
             "remark-gfm": "^3.0.1",
             "shiki": "^0.10.1",
             "unified": "^10.1.2"
@@ -20222,6 +20300,19 @@
             "unist-util-visit": "^4.0.0"
           }
         },
+        "mdast-util-directive": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-2.2.1.tgz",
+          "integrity": "sha512-yZRRuaulzc6bM4IOyZfkOrVs+9Sf1BC+rldRXJyl/Ej6S/6ewQQ9jt75HvEoqZZ4m9ealVTHiS4MP2GRUE7INA==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "mdast-util-to-markdown": "^1.3.0",
+            "parse-entities": "^4.0.0",
+            "stringify-entities": "^4.0.0",
+            "unist-util-visit-parents": "^5.0.0"
+          }
+        },
         "mdast-util-find-and-replace": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.1.tgz",
@@ -20625,6 +20716,20 @@
             "micromark-util-subtokenize": "^1.0.0",
             "micromark-util-symbol": "^1.0.0",
             "micromark-util-types": "^1.0.1",
+            "uvu": "^0.5.0"
+          }
+        },
+        "micromark-extension-directive": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-2.1.1.tgz",
+          "integrity": "sha512-+7MYZ3a10cpPrQRg3530srFMSBx0EL7gQaJ3ekguOQFSlJHLikW15AphBmNxvCNdRSWTX1R8RepzjKQra8INQw==",
+          "requires": {
+            "micromark-factory-space": "^1.0.0",
+            "micromark-factory-whitespace": "^1.0.0",
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.0",
+            "parse-entities": "^4.0.0",
             "uvu": "^0.5.0"
           }
         },
@@ -22805,6 +22910,26 @@
             "unified": "^10.0.0"
           }
         },
+        "remark-directive": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-2.0.1.tgz",
+          "integrity": "sha512-oosbsUAkU/qmUE78anLaJePnPis4ihsE7Agp0T/oqTzvTea8pOiaYEtfInU/+xMOVTS9PN5AhGOiaIVe4GD8gw==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "mdast-util-directive": "^2.0.0",
+            "micromark-extension-directive": "^2.0.0",
+            "unified": "^10.0.0"
+          }
+        },
+        "remark-directive-rehype": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/remark-directive-rehype/-/remark-directive-rehype-0.4.0.tgz",
+          "integrity": "sha512-RrcjHXJ566myykjUIx3UNFxrAfHxFJeGK1jF8uqrxq5sBxO8YRBkg/W4640wqX5NCXny7khrqH23Dag8kYCl5A==",
+          "requires": {
+            "hastscript": "^7.0.2",
+            "unist-util-map": "^3.0.0"
+          }
+        },
         "remark-frontmatter": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
@@ -23710,6 +23835,14 @@
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
           "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
         },
+        "unist-util-map": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.1.1.tgz",
+          "integrity": "sha512-n36sjBn4ibPtAzrFweyT4FOcCI/UdzboaEcsZvwoAyD/gVw5B3OLlMBySePMO6r+uzjxQEyRll2akfVaT4SHhw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
         "unist-util-modify-children": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-3.0.0.tgz",
@@ -24196,6 +24329,8 @@
         "rehype-autolink-headings": "^6.1.1",
         "rehype-parse": "^8.0.4",
         "rehype-slug": "^5.0.1",
+        "remark-directive": "^2.0.1",
+        "remark-directive-rehype": "*",
         "remark-gfm": "^3.0.1",
         "shiki": "^0.10.1",
         "unified": "^10.1.2"
@@ -30235,6 +30370,19 @@
         "unist-util-visit": "^4.0.0"
       }
     },
+    "mdast-util-directive": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-2.2.1.tgz",
+      "integrity": "sha512-yZRRuaulzc6bM4IOyZfkOrVs+9Sf1BC+rldRXJyl/Ej6S/6ewQQ9jt75HvEoqZZ4m9ealVTHiS4MP2GRUE7INA==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      }
+    },
     "mdast-util-find-and-replace": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.1.tgz",
@@ -30638,6 +30786,20 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-directive": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-2.1.1.tgz",
+      "integrity": "sha512-+7MYZ3a10cpPrQRg3530srFMSBx0EL7gQaJ3ekguOQFSlJHLikW15AphBmNxvCNdRSWTX1R8RepzjKQra8INQw==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "parse-entities": "^4.0.0",
         "uvu": "^0.5.0"
       }
     },
@@ -32818,6 +32980,26 @@
         "unified": "^10.0.0"
       }
     },
+    "remark-directive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-2.0.1.tgz",
+      "integrity": "sha512-oosbsUAkU/qmUE78anLaJePnPis4ihsE7Agp0T/oqTzvTea8pOiaYEtfInU/+xMOVTS9PN5AhGOiaIVe4GD8gw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-directive": "^2.0.0",
+        "micromark-extension-directive": "^2.0.0",
+        "unified": "^10.0.0"
+      }
+    },
+    "remark-directive-rehype": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/remark-directive-rehype/-/remark-directive-rehype-0.4.0.tgz",
+      "integrity": "sha512-RrcjHXJ566myykjUIx3UNFxrAfHxFJeGK1jF8uqrxq5sBxO8YRBkg/W4640wqX5NCXny7khrqH23Dag8kYCl5A==",
+      "requires": {
+        "hastscript": "^7.0.2",
+        "unist-util-map": "^3.0.0"
+      }
+    },
     "remark-frontmatter": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
@@ -33722,6 +33904,14 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
       "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+    },
+    "unist-util-map": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.1.1.tgz",
+      "integrity": "sha512-n36sjBn4ibPtAzrFweyT4FOcCI/UdzboaEcsZvwoAyD/gVw5B3OLlMBySePMO6r+uzjxQEyRll2akfVaT4SHhw==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
     },
     "unist-util-modify-children": {
       "version": "3.0.0",

--- a/packages/contented-example/docs/01:overview.md
+++ b/packages/contented-example/docs/01:overview.md
@@ -116,3 +116,9 @@ export default {
 
 - [BirthdayResearch/contented/packages/contented-example](https://github.com/BirthdayResearch/contented/tree/main/packages/contented-example)
 - [fuxingloh/jellyfishsdk-docs](https://github.com/fuxingloh/jellyfishsdk-docs)
+
+## Just Another SSG?
+
+This is not a static site generator. This is a markdown processor workflow with a built-in static site generator. The
+outcome we're trying to achieve is
+this [@birthdayresearch/contented-example/dist](https://www.jsdelivr.com/package/npm/@birthdayresearch/contented-example)

--- a/packages/contented-example/docs/04:markdown.md
+++ b/packages/contented-example/docs/04:markdown.md
@@ -1,0 +1,81 @@
+---
+title: Markdown Features
+---
+
+```js
+builder
+  .use(remarkGfm)
+  .use(remarkFrontmatter)
+  .use(remarkParse)
+  .use(remarkDirective)
+  .use(remarkDirectiveRehype)
+  .use(remarkRehype)
+  .use(rehypeSlug)
+  .use(rehypeAutolinkHeadings)
+  .use(rehypeToc)
+  .use(rehypeShiki, { highlighter })
+  .use(rehypeStringify);
+```
+
+## GitHub Flavour Markdown
+
+[GitHub Flavored Markdown](https://github.github.com/gfm/), often shortened as GFM, is the dialect of Markdown that is
+currently supported for user content on GitHub.com and GitHub Enterprise.
+
+This formal specification, based on the CommonMark Spec, defines the syntax and semantics of this dialect.
+
+## Frontmatter
+
+```markdown
+---
+title: Markdown Flavour
+---
+```
+
+## Admonitions
+
+Admonitions with `remark-directive` and `remark-directive-rehype`.
+
+::::div{class="admonitions"}
+This is `div{class="admonitions"}`.
+
+```markdown
+:::div{class="admonitions"}
+This is `div{class="admonitions"}`.
+:::
+```
+
+::::
+
+::::div{class="admonitions red"}
+This is `div{class="admonitions red"}`.
+
+```markdown
+:::div{class="admonitions red"}
+This is `div{class="admonitions red"}`.
+:::
+```
+
+::::
+
+::::div{class="admonitions yellow"}
+This is `div{class="admonitions yellow"}`.
+
+```markdown
+:::div{class="admonitions yellow"}
+This is `div{class="admonitions yellow"}`.
+:::
+```
+
+::::
+
+::::div{class="admonitions green"}
+This is `div{class="admonitions green"}`.
+
+```markdown
+:::div{class="admonitions green"}
+This is `div{class="admonitions green"}`.
+:::
+```
+
+::::

--- a/packages/contented-preview/src/styles/prose.css
+++ b/packages/contented-preview/src/styles/prose.css
@@ -1,3 +1,44 @@
-.prose nav.toc {
+.prose .toc {
   @apply sr-only;
+}
+
+.prose .admonitions {
+  @apply relative my-6 rounded-r py-0.5 px-6;
+  @apply before:absolute before:inset-0 before:h-full before:w-1;
+  @apply dark:text-slate-200;
+
+  @apply before:bg-slate-500 before:dark:bg-slate-600;
+  @apply bg-slate-100 dark:bg-slate-800;
+}
+
+.prose .admonitions.red {
+  @apply before:bg-red-500 before:dark:bg-red-600;
+  @apply bg-red-100 dark:bg-red-800;
+}
+
+.prose .admonitions.yellow {
+  @apply before:bg-amber-500 before:dark:bg-amber-600;
+  @apply bg-amber-100 dark:bg-amber-800;
+}
+
+.prose .admonitions.green {
+  @apply before:bg-green-500 before:dark:bg-green-600;
+  @apply bg-green-100 dark:bg-green-800;
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6) {
+  @apply -ml-6 pl-6;
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6):hover > a {
+  @apply block;
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6) > a {
+  @apply hidden;
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6) a:before {
+  content: '#';
+  @apply text-primary-500 absolute -ml-6;
 }

--- a/packages/contented-processor/package.json
+++ b/packages/contented-processor/package.json
@@ -32,6 +32,8 @@
     "rehype-autolink-headings": "^6.1.1",
     "rehype-parse": "^8.0.4",
     "rehype-slug": "^5.0.1",
+    "remark-directive": "^2.0.1",
+    "remark-directive-rehype": "^0.4.0",
     "remark-gfm": "^3.0.1",
     "shiki": "^0.10.1",
     "unified": "^10.1.2"

--- a/packages/contented-processor/unified.ts
+++ b/packages/contented-processor/unified.ts
@@ -3,6 +3,8 @@ import rehypeShiki from '@leafac/rehype-shiki';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeSlug from 'rehype-slug';
 import rehypeStringify from 'rehype-stringify';
+import remarkDirective from 'remark-directive';
+import remarkDirectiveRehype from 'remark-directive-rehype';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
@@ -25,6 +27,8 @@ export async function getUnifiedProcessor(options?: UnifiedOptions): Promise<(bu
       .use(remarkGfm)
       .use(remarkFrontmatter)
       .use(remarkParse)
+      .use(remarkDirective)
+      .use(remarkDirectiveRehype)
       .use(remarkRehype)
       .use(rehypeSlug)
       .use(rehypeAutolinkHeadings)


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `remark-directive` and `remark-directive-rehype` into the unified processor.

---

For convenience, I added default admonitions styling.

```markdown
:::div{class="admonitions"}
This is `div{class="admonitions"}`.
:::
```

Also added .prose h1,h2,.. auto link styling.