### PR TITLE
chore(contented-processor): add default fields for convenience

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import { DocumentTypes } from 'contentlayer/source-files';
-
 export interface ContentedPreview {
   url?: string;
   name?: string;
@@ -9,9 +7,20 @@ export interface ContentedPreview {
 }
 
 export interface ContentedConfig {
+  /**
+   * The root directory of your contented markdown. You can specify a sub-path.
+   */
   rootDir: string;
-  unified(): Promise<unified.Processor>;
-  types: DocumentTypes;
+
+  /**
+   * Customizing the unified processor.
+   */
+  unified?: () => Promise<unified.Processor>;
+
+  /**
+   * Defining Contentlayer DocumentTypes.
+   */
+  types: import('contentlayer/source-files').DocumentTypes;
 }
 
 export default {} as ContentedConfig;

--- a/packages/contented-example/contented.js
+++ b/packages/contented-example/contented.js
@@ -1,12 +1,4 @@
-import {
-  defineDocumentType,
-  getUnifiedProcessor,
-  computeContentHeadings,
-  computePath,
-  computeSections,
-} from '@birthdayresearch/contented-processor';
-
-const Doc = defineDocumentType(() => ({
+const Doc = {
   name: 'Doc',
   filePathPattern: `**/*.md`,
   fields: {
@@ -20,16 +12,16 @@ const Doc = defineDocumentType(() => ({
       type: 'string',
       required: false,
     },
+    tags: {
+      type: 'list',
+      of: { type: 'string' },
+      default: [],
+      required: false,
+    },
   },
-  computedFields: {
-    path: computePath('/', /\d+:/g, ''),
-    sections: computeSections(undefined, /\d+:/g, ''),
-    contentHeadings: computeContentHeadings(),
-  },
-}));
+};
 
 export default {
   rootDir: 'docs',
-  unified: getUnifiedProcessor,
   types: [Doc],
 };

--- a/packages/contented-example/docs/01:overview.md
+++ b/packages/contented-example/docs/01:overview.md
@@ -75,17 +75,9 @@ repo/
 **contented.js**
 
 ```js
-import {
-  defineDocumentType,
-  getUnifiedProcessor,
-  computeContentHeadings,
-  computePath,
-  computeSections,
-} from '@birthdayresearch/contented-processor';
-
-const Doc = defineDocumentType(() => ({
+const Doc = {
   name: 'Doc',
-  filePathPattern: `docs/**/*.md`,
+  filePathPattern: `**/*.md`,
   fields: {
     title: {
       type: 'string',
@@ -97,17 +89,17 @@ const Doc = defineDocumentType(() => ({
       type: 'string',
       required: false,
     },
+    tags: {
+      type: 'list',
+      of: { type: 'string' },
+      default: [],
+      required: false,
+    },
   },
-  computedFields: {
-    path: computePath('/', /\d+:/g, ''),
-    sections: computeSections(/docs\/?/g, /\d+:/g, ''),
-    contentHeadings: computeContentHeadings(),
-  },
-}));
+};
 
 export default {
-  rootDir: './',
-  unified: getUnifiedProcessor,
+  rootDir: 'docs',
   types: [Doc],
 };
 ```

--- a/packages/contented-example/docs/03:api.md
+++ b/packages/contented-example/docs/03:api.md
@@ -86,14 +86,14 @@ The anatomy of a contented package, with just 2 configuration files, and you are
 ```typescript
 export interface ContentedConfig {
   /**
-   * The root directory of your contented markdown. You can specifiy a subpath.
+   * The root directory of your contented markdown. You can specify a sub-path.
    */
   rootDir: string;
 
   /**
    * Customizing the unified processor.
    */
-  unified(): Promise<unified.Processor>;
+  unified?: () => Promise<unified.Processor>;
 
   /**
    * Defining Contentlayer DocumentTypes.
@@ -105,31 +105,31 @@ export interface ContentedConfig {
 #### Example
 
 ```js
-import {
-  defineDocumentType,
-  getUnifiedProcessor,
-  computeContentHeadings,
-  computePath,
-  computeSections,
-} from '@birthdayresearch/contented-processor';
-
-const Doc = defineDocumentType(() => ({
+const Doc = {
   name: 'Doc',
-  filePathPattern: `docs/**/*.md`,
+  filePathPattern: `**/*.md`,
   fields: {
-    title: { type: 'string', required: true },
-    description: { type: 'string', required: false },
+    title: {
+      type: 'string',
+      description: 'The title of the documentation.',
+      required: true,
+      default: 'Contented',
+    },
+    description: {
+      type: 'string',
+      required: false,
+    },
+    tags: {
+      type: 'list',
+      of: { type: 'string' },
+      default: [],
+      required: false,
+    },
   },
-  computedFields: {
-    path: computePath('/', /\d+:/g, ''),
-    sections: computeSections(/docs\/?/g, /\d+:/g, ''),
-    contentHeadings: computeContentHeadings(),
-  },
-}));
+};
 
 export default {
-  rootDir: './',
-  unified: getUnifiedProcessor,
+  rootDir: 'docs',
   types: [Doc],
 };
 ```

--- a/packages/contented-example/docs/04:markdown.md
+++ b/packages/contented-example/docs/04:markdown.md
@@ -1,5 +1,7 @@
 ---
 title: Markdown Features
+description: The dialect of Markdown that is currently supported for contented
+tags: ['Markdown', 'Frontmatter', 'Admonitions', 'Mermaid']
 ---
 
 ```js

--- a/packages/contented-preview/contentlayer.config.js
+++ b/packages/contented-preview/contentlayer.config.js
@@ -4,11 +4,60 @@ import { makeSource } from 'contentlayer/source-files';
 // noinspection JSFileReferences
 import contented from '../contented';
 
+import {
+  defineDocumentType,
+  getUnifiedProcessor,
+  computeContentHeadings,
+  computePath,
+  computeSections,
+} from '@birthdayresearch/contented-processor';
+
+const defaultFields = {
+  title: {
+    type: 'string',
+    required: false,
+  },
+  description: {
+    type: 'string',
+    required: false,
+  },
+  tags: {
+    type: 'list',
+    of: { type: 'string' },
+    default: [],
+    required: false,
+  },
+};
+
+const defaultComputedFields = {
+  path: computePath('/', /\d+:/g, ''),
+  sections: computeSections(undefined, /\d+:/g, ''),
+  contentHeadings: computeContentHeadings(),
+};
+
 async function makeConfig() {
+  const types = contented.types.map((type) => {
+    return defineDocumentType(() => {
+      return {
+        ...type,
+        fields: {
+          ...defaultFields,
+          ...type.fields ?? {},
+        },
+        computedFields: {
+          ...type.documentTypes ?? {},
+          ...defaultComputedFields,
+        },
+      };
+    });
+  });
+
+  const processor = await (contented.unified?.() ?? getUnifiedProcessor());
+
   return makeSource({
     contentDirPath: join('../', contented.rootDir),
-    markdown: await contented.unified(),
-    documentTypes: contented.types,
+    markdown: processor,
+    documentTypes: types,
     contentDirExclude: ['dist', '.next', 'out', '.contented'],
     onUnknownDocuments: 'skip-ignore',
     disableImportAliasWarning: true,

--- a/packages/contented-preview/src/pages/[[...slug]].page.jsx
+++ b/packages/contented-preview/src/pages/[[...slug]].page.jsx
@@ -1,15 +1,15 @@
 // noinspection ES6PreferShortImport
-import { allDocuments } from '../../.contentlayer/generated';
 import truncate from 'lodash/truncate';
+import mermaid from 'mermaid';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
+import { allDocuments } from '../../.contentlayer/generated';
 import ContentHeadings from './_components/ContentHeadings';
 import ContentNavigation, { computeContentSections } from './_components/ContentNavigation';
 import ContentProse from './_components/ContentProse';
-import { useEffect, useState } from 'react';
 import { useTheme } from './_components/ThemeContext';
-import mermaid from 'mermaid';
-import { useRouter } from 'next/router';
 
 export async function getStaticPaths() {
   return {
@@ -86,7 +86,7 @@ export default function SlugPage({ doc, sections }) {
 
         <div className="hidden xl:sticky xl:top-[4.5rem] xl:-mr-6 xl:block xl:h-[calc(100vh-4.5rem)] xl:flex-none xl:overflow-y-auto xl:py-16 xl:pr-6">
           <nav aria-labelledby="on-this-page-title" className="w-56">
-            <ContentHeadings contentHeadings={doc.contentHeadings} />
+            <ContentHeadings contentHeadings={doc.contentHeadings} tags={doc.tags} />
           </nav>
         </div>
       </div>

--- a/packages/contented-preview/src/pages/_components/ContentHeadings.jsx
+++ b/packages/contented-preview/src/pages/_components/ContentHeadings.jsx
@@ -1,8 +1,33 @@
+import clsx from 'clsx';
 import Link from 'next/link';
 
 export default function ContentHeadings(props) {
   return (
     <>
+      {props.tags.length > 0 && (
+        <>
+          <h2 id="tags-title" className="font-display text-sm font-medium text-slate-900 dark:text-white">
+            Tags
+          </h2>
+          <div className="mt-4 mb-6">
+            <div className="-mx-1.5 -my-1 flex flex-wrap">
+              {props.tags.map((tag) => (
+                <div key={tag} className="px-1.5 py-1">
+                  <span
+                    className={clsx(
+                      'rounded px-2 py-1 text-sm font-medium',
+                      'bg-slate-100 text-slate-700',
+                      'dark:bg-slate-800 dark:text-slate-400',
+                    )}
+                  >
+                    {tag}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
       {props.contentHeadings.length > 0 && (
         <>
           <h2 id="on-this-page-title" className="font-display text-sm font-medium text-slate-900 dark:text-white">


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Moved `path`, `sections`, `contentHeadings` to default computed fields.
- Moved `title: string`, `description: string` & `tags: string[]` to default fields.