### PR TITLE
chore(content-preview): ignore node_modules

### DIFF
--- a/packages/contented-preview/contentlayer.config.js
+++ b/packages/contented-preview/contentlayer.config.js
@@ -58,7 +58,7 @@ async function makeConfig() {
     contentDirPath: join('../', contented.rootDir),
     markdown: processor,
     documentTypes: types,
-    contentDirExclude: ['dist', '.next', 'out', '.contented'],
+    contentDirExclude: ['dist', '.next', 'out', '.contented', 'node_modules'],
     onUnknownDocuments: 'skip-ignore',
     disableImportAliasWarning: true,
   });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

For convenience, add `node_modules` to `contentDirExclude` for any repo that uses `contented.js` at the root.
