### PR TITLE
chore(contented): contented-preview have its own package.json now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage
 
 # contented
 .contented
+.preview

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ coverage
 
 # contented
 .contented
-.preview

--- a/.idea/contented.iml
+++ b/.idea/contented.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/packages/contented/.preview" />
       <excludePattern pattern="*.contented*" />
       <excludePattern pattern="*.turbo*" />
       <excludePattern pattern="*dist*" />

--- a/packages/contented-preview/cli.js
+++ b/packages/contented-preview/cli.js
@@ -1,8 +1,0 @@
-#! /usr/bin/env node
-const { cpSync } = require('node:fs');
-
-const contentedDir = `${process.cwd()}/.contented/.preview`;
-
-cpSync(`${__dirname}`, contentedDir, {
-  recursive: true,
-});

--- a/packages/contented-preview/package.json
+++ b/packages/contented-preview/package.json
@@ -2,9 +2,6 @@
   "name": "@birthdayresearch/contented-preview",
   "version": "0.0.0",
   "private": false,
-  "bin": {
-    "contented-preview": "./cli.js"
-  },
   "scripts": {
     "dev": "next dev",
     "export": "next build && next-sitemap && next export"

--- a/packages/contented/build-preview.js
+++ b/packages/contented/build-preview.js
@@ -14,6 +14,6 @@ const files = [
 
 for (const file of files) {
   const source = join(process.cwd(), '/../contented-preview', file);
-  const target = join(process.cwd(), '/.preview', file);
+  const target = join(process.cwd(), '/dist/.preview', file);
   cpSync(source, target, { recursive: true });
 }

--- a/packages/contented/build-preview.js
+++ b/packages/contented/build-preview.js
@@ -1,0 +1,19 @@
+#! /usr/bin/env node
+import { cpSync } from 'node:fs';
+import { join } from 'node:path';
+
+const files = [
+  'public',
+  'src',
+  'next.config.js',
+  'next-sitemap.config.js',
+  'package.json',
+  'postcss.config.js',
+  'tailwind.config.js',
+];
+
+for (const file of files) {
+  const source = join(process.cwd(), '/../contented-preview', file);
+  const target = join(process.cwd(), '/.preview', file);
+  cpSync(source, target, { recursive: true });
+}

--- a/packages/contented/package.json
+++ b/packages/contented/package.json
@@ -11,10 +11,11 @@
   },
   "files": [
     "dist",
+    ".preview",
     "cli.js"
   ],
   "scripts": {
-    "build": "tsc -b ./tsconfig.build.json",
+    "build": "tsc -b ./tsconfig.build.json && node build-preview.js",
     "clean": "rm -rf dist",
     "lint": "eslint src"
   },
@@ -27,7 +28,6 @@
     ]
   },
   "dependencies": {
-    "@birthdayresearch/contented-preview": "0.0.0",
     "@birthdayresearch/contented-processor": "0.0.0",
     "chokidar": "^3.5.3",
     "clipanion": "3.2.0-rc.11",

--- a/packages/contented/src/commands/ContentedPreview.ts
+++ b/packages/contented/src/commands/ContentedPreview.ts
@@ -1,0 +1,38 @@
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cp } from 'node:fs/promises';
+import { spawn, spawnSync } from 'node:child_process';
+
+export class ContentedPreview {
+  previewDir = `${process.cwd()}/.contented/.preview`;
+
+  async init() {
+    const source = join(this.getDirname(), '/../.preview');
+    await cp(source, this.previewDir, { recursive: true });
+  }
+
+  async install() {
+    spawnSync(`npm`, ['i'], {
+      stdio: 'inherit',
+      cwd: this.previewDir,
+    });
+  }
+
+  async write() {
+    spawn(`npm`, ['run', 'dev'], {
+      stdio: 'inherit',
+      cwd: this.previewDir,
+    });
+  }
+
+  async generate() {
+    spawnSync(`npm`, ['run', 'export'], {
+      stdio: 'inherit',
+      cwd: this.previewDir,
+    });
+  }
+
+  getDirname() {
+    return dirname(fileURLToPath(import.meta.url));
+  }
+}

--- a/packages/contented/src/commands/ContentedPreview.ts
+++ b/packages/contented/src/commands/ContentedPreview.ts
@@ -1,7 +1,7 @@
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { cp } from 'node:fs/promises';
 import { spawn, spawnSync } from 'node:child_process';
+import { cp } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export class ContentedPreview {
   previewDir = `${process.cwd()}/.contented/.preview`;

--- a/packages/contented/src/commands/GenerateCommand.ts
+++ b/packages/contented/src/commands/GenerateCommand.ts
@@ -1,7 +1,6 @@
 import { ContentedProcessor } from '@birthdayresearch/contented-processor';
-import { spawnSync } from 'node:child_process';
-
 import { BuildCommand } from './BuildCommand.js';
+import { ContentedPreview } from './ContentedPreview.js';
 
 export class GenerateCommand extends BuildCommand {
   static paths = [[`generate`]];
@@ -11,12 +10,9 @@ export class GenerateCommand extends BuildCommand {
     const processor = new ContentedProcessor(config.processor);
     await this.walk(processor);
 
-    spawnSync(`contented-preview`, [], { stdio: 'inherit' });
-
-    const previewDir = `${process.cwd()}/.contented/.preview`;
-    spawnSync(`npm`, ['run', 'export', '--prefix', previewDir], {
-      stdio: 'inherit',
-      cwd: previewDir,
-    });
+    const preview = new ContentedPreview();
+    await preview.init();
+    await preview.install();
+    await preview.generate();
   }
 }

--- a/packages/contented/src/commands/GenerateCommand.ts
+++ b/packages/contented/src/commands/GenerateCommand.ts
@@ -1,4 +1,5 @@
 import { ContentedProcessor } from '@birthdayresearch/contented-processor';
+
 import { BuildCommand } from './BuildCommand.js';
 import { ContentedPreview } from './ContentedPreview.js';
 

--- a/packages/contented/src/commands/WriteCommand.ts
+++ b/packages/contented/src/commands/WriteCommand.ts
@@ -1,6 +1,5 @@
-import { spawn, spawnSync } from 'node:child_process';
-
 import { WatchCommand } from './WatchCommand.js';
+import { ContentedPreview } from './ContentedPreview.js';
 
 export class WriteCommand extends WatchCommand {
   static paths = [[`write`]];
@@ -8,12 +7,9 @@ export class WriteCommand extends WatchCommand {
   async execute() {
     await super.execute();
 
-    spawnSync(`contented-preview`);
-
-    const previewDir = `${process.cwd()}/.contented/.preview`;
-    spawn(`npm`, ['run', 'dev', '--prefix', previewDir], {
-      stdio: 'inherit',
-      cwd: previewDir,
-    });
+    const preview = new ContentedPreview();
+    await preview.init();
+    await preview.install();
+    await preview.write();
   }
 }

--- a/packages/contented/src/commands/WriteCommand.ts
+++ b/packages/contented/src/commands/WriteCommand.ts
@@ -1,5 +1,5 @@
-import { WatchCommand } from './WatchCommand.js';
 import { ContentedPreview } from './ContentedPreview.js';
+import { WatchCommand } from './WatchCommand.js';
 
 export class WriteCommand extends WatchCommand {
   static paths = [[`write`]];


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Remove npm spawning, `contented-preview` will be copied over to `contented` and have all the files it needs to spawn preview without requiring previous installation into `node_modules`.