### PR TITLE
chore(contented-preview): version lock all the deps due to "npm i" drift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17635,19 +17635,19 @@
       "name": "@birthdayresearch/contented-preview",
       "version": "0.0.0",
       "dependencies": {
-        "@headlessui/react": "^1.6.6",
-        "@heroicons/react": "^1.0.6",
-        "@tailwindcss/line-clamp": "^0.4.0",
-        "@tailwindcss/typography": "^0.5.4",
-        "autoprefixer": "^10.4.7",
-        "clsx": "^1.2.1",
-        "mermaid": "^9.1.3",
+        "@headlessui/react": "1.6.6",
+        "@heroicons/react": "1.0.6",
+        "@tailwindcss/line-clamp": "0.4.0",
+        "@tailwindcss/typography": "0.5.4",
+        "autoprefixer": "10.4.7",
+        "clsx": "1.2.1",
+        "mermaid": "9.1.3",
         "next": "12.2.3",
-        "next-sitemap": "^3.1.13",
-        "postcss": "^8.4.14",
+        "next-sitemap": "3.1.13",
+        "postcss": "8.4.14",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "tailwindcss": "^3.1.6"
+        "tailwindcss": "3.1.6"
       }
     },
     "packages/contented-processor": {
@@ -18166,19 +18166,19 @@
     "@birthdayresearch/contented-preview": {
       "version": "file:packages/contented-preview",
       "requires": {
-        "@headlessui/react": "^1.6.6",
-        "@heroicons/react": "^1.0.6",
-        "@tailwindcss/line-clamp": "^0.4.0",
-        "@tailwindcss/typography": "^0.5.4",
-        "autoprefixer": "^10.4.7",
-        "clsx": "^1.2.1",
-        "mermaid": "^9.1.3",
+        "@headlessui/react": "1.6.6",
+        "@heroicons/react": "1.0.6",
+        "@tailwindcss/line-clamp": "0.4.0",
+        "@tailwindcss/typography": "0.5.4",
+        "autoprefixer": "10.4.7",
+        "clsx": "1.2.1",
+        "mermaid": "9.1.3",
         "next": "12.2.3",
-        "next-sitemap": "^3.1.13",
-        "postcss": "^8.4.14",
+        "next-sitemap": "3.1.13",
+        "postcss": "8.4.14",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "tailwindcss": "^3.1.6"
+        "tailwindcss": "3.1.6"
       }
     },
     "@birthdayresearch/contented-processor": {

--- a/packages/contented-preview/package.json
+++ b/packages/contented-preview/package.json
@@ -7,18 +7,18 @@
     "export": "next build && next-sitemap && next export"
   },
   "dependencies": {
-    "@headlessui/react": "^1.6.6",
-    "@heroicons/react": "^1.0.6",
-    "@tailwindcss/line-clamp": "^0.4.0",
-    "@tailwindcss/typography": "^0.5.4",
-    "autoprefixer": "^10.4.7",
-    "clsx": "^1.2.1",
-    "mermaid": "^9.1.3",
+    "@headlessui/react": "1.6.6",
+    "@heroicons/react": "1.0.6",
+    "@tailwindcss/line-clamp": "0.4.0",
+    "@tailwindcss/typography": "0.5.4",
+    "autoprefixer": "10.4.7",
+    "clsx": "1.2.1",
+    "mermaid": "9.1.3",
     "next": "12.2.3",
-    "next-sitemap": "^3.1.13",
-    "postcss": "^8.4.14",
+    "next-sitemap": "3.1.13",
+    "postcss": "8.4.14",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwindcss": "^3.1.6"
+    "tailwindcss": "3.1.6"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Since `contented` cli will `npm i` the `contented-preview`, version lock without `^` will prevent deps drift.
