### PR TITLE
feat(contented-processor): allow contented-pipeline to be injected

### DIFF
--- a/packages/contented-pipeline/src/Pipeline.ts
+++ b/packages/contented-pipeline/src/Pipeline.ts
@@ -9,7 +9,7 @@ import { FileContent, FileIndex } from './PipelineFile.js';
 export interface Pipeline {
   type: string;
   pattern: string | string[];
-  processor: 'md';
+  processor: 'md' | ContentedPipeline;
   fields?: {
     [name: string]: PipelineField;
   };
@@ -22,6 +22,11 @@ export interface Pipeline {
  */
 export abstract class ContentedPipeline {
   public constructor(protected readonly pipeline: Pipeline) {}
+
+  /**
+   * Optional init for Pipeline that require async setup.
+   */
+  async init(): Promise<void> {} // eslint-disable-line @typescript-eslint/no-empty-function
 
   async process(rootPath: string, file: string): Promise<FileContent | undefined> {
     const fileIndex = await this.newFileIndex(rootPath, file);

--- a/packages/contented-processor/src/ContentedProcessor.ts
+++ b/packages/contented-processor/src/ContentedProcessor.ts
@@ -110,16 +110,23 @@ export class ContentedProcessor {
     }
 
     const cacheKey = getPipelineUniqueKey(pipeline);
-    const processor = this.pipelines[cacheKey];
-    if (processor !== undefined) {
-      return processor;
+    if (this.pipelines[cacheKey] === undefined) {
+      this.pipelines[cacheKey] = await this.newProcessor(pipeline);
     }
 
+    return this.pipelines[cacheKey];
+  }
+
+  private async newProcessor(pipeline: Pipeline): Promise<ContentedPipeline> {
     if (pipeline.processor === 'md') {
-      const mdProcessor = new MarkdownPipeline(pipeline);
-      await mdProcessor.init();
-      this.pipelines[cacheKey] = mdProcessor;
-      return mdProcessor;
+      const md = new MarkdownPipeline(pipeline);
+      await md.init();
+      return md;
+    }
+
+    if (pipeline.processor instanceof ContentedPipeline) {
+      await pipeline.processor.init();
+      return pipeline.processor;
     }
 
     throw new Error(`pipeline.category: ${pipeline.type} processor not found.`);


### PR DESCRIPTION
#### What this PR does / why we need it:

You can specify and create your own `ContentedPipeline` in the `pipelines: [ {processor: ... }]` field now. The key/type `md` is the short form of the built-in `MarkdownPipeline`.
