### PR TITLE
feat(contented-processor): instead of providing the ContentedPipeline, ES import it

### DIFF
--- a/packages/contented-pipeline/src/Pipeline.ts
+++ b/packages/contented-pipeline/src/Pipeline.ts
@@ -9,7 +9,11 @@ import { FileContent, FileIndex } from './PipelineFile.js';
 export interface Pipeline {
   type: string;
   pattern: string | string[];
-  processor: 'md' | ContentedPipeline;
+  /**
+   * Built in processor: 'md'
+   * Otherwise it will `import(processor)` module with default exporting ContentedPipeline
+   */
+  processor: 'md' | string;
   fields?: {
     [name: string]: PipelineField;
   };

--- a/packages/contented-processor/src/ContentedProcessor.ts
+++ b/packages/contented-processor/src/ContentedProcessor.ts
@@ -118,15 +118,19 @@ export class ContentedProcessor {
   }
 
   private async newProcessor(pipeline: Pipeline): Promise<ContentedPipeline> {
-    if (pipeline.processor === 'md') {
-      const md = new MarkdownPipeline(pipeline);
-      await md.init();
-      return md;
-    }
+    const newPipeline = async (): Promise<ContentedPipeline> => {
+      switch (pipeline.processor) {
+        case 'md':
+          return new MarkdownPipeline(pipeline);
+        default:
+          return import(pipeline.processor);
+      }
+    };
 
-    if (pipeline.processor instanceof ContentedPipeline) {
-      await pipeline.processor.init();
-      return pipeline.processor;
+    const processor = await newPipeline();
+    if (processor) {
+      await processor.init();
+      return processor;
     }
 
     throw new Error(`pipeline.category: ${pipeline.type} processor not found.`);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

By default it provides, a built-in processor called `'md'`. Otherwise, you can provide a string, and it will `import(processor)` module with default exporting ContentedPipeline.