### PR TITLE
feat(contented-processor): revert old behavior of allowing custom Pipeline to be injected

### DIFF
--- a/packages/contented-example/contented.config.js
+++ b/packages/contented-example/contented.config.js
@@ -1,3 +1,5 @@
+import { MarkdownPipeline } from '@birthdayresearch/contented-pipeline-md';
+
 /** @type {import('@birthdayresearch/contented').ContentedConfig} */
 const config = {
   preview: {
@@ -35,7 +37,7 @@ const config = {
       {
         type: 'Lorem',
         pattern: 'lorem/**/*.md',
-        processor: 'md',
+        processor: MarkdownPipeline,
         fields: {
           title: {
             type: 'string',

--- a/packages/contented-example/package.json
+++ b/packages/contented-example/package.json
@@ -14,6 +14,7 @@
     "write": "contented write"
   },
   "devDependencies": {
-    "@birthdayresearch/contented": "0.0.0"
+    "@birthdayresearch/contented": "0.0.0",
+    "@birthdayresearch/contented-pipeline-md": "0.0.0"
   }
 }

--- a/packages/contented-pipeline-md/src/plugins/RehypeMermaid.ts
+++ b/packages/contented-pipeline-md/src/plugins/RehypeMermaid.ts
@@ -26,7 +26,6 @@ function visitLanguageMermaid(node: Element) {
     return;
   }
 
-  /* eslint-disable no-param-reassign */
   node.properties = {
     ...node.properties,
     className: ['mermaid'],

--- a/packages/contented-pipeline/src/Pipeline.ts
+++ b/packages/contented-pipeline/src/Pipeline.ts
@@ -13,7 +13,7 @@ export interface Pipeline {
    * Built in processor: 'md'
    * Otherwise it will `import(processor)` module with default exporting ContentedPipeline
    */
-  processor: 'md' | string;
+  processor: 'md' | (new (pipeline: Pipeline) => ContentedPipeline);
   fields?: {
     [name: string]: PipelineField;
   };

--- a/packages/contented-processor/src/ContentedProcessor.ts
+++ b/packages/contented-processor/src/ContentedProcessor.ts
@@ -123,6 +123,7 @@ export class ContentedProcessor {
         case 'md':
           return new MarkdownPipeline(pipeline);
         default:
+          // eslint-disable-next-line new-cap
           return new pipeline.processor(pipeline);
       }
     };

--- a/packages/contented-processor/src/ContentedProcessor.ts
+++ b/packages/contented-processor/src/ContentedProcessor.ts
@@ -118,12 +118,12 @@ export class ContentedProcessor {
   }
 
   private async newProcessor(pipeline: Pipeline): Promise<ContentedPipeline> {
-    const newPipeline = async (): Promise<ContentedPipeline> => {
+    const newPipeline = (): ContentedPipeline => {
       switch (pipeline.processor) {
         case 'md':
           return new MarkdownPipeline(pipeline);
         default:
-          return import(pipeline.processor);
+          return new pipeline.processor(pipeline);
       }
     };
 

--- a/packages/contented-processor/src/ContentedProcessor.unit.ts
+++ b/packages/contented-processor/src/ContentedProcessor.unit.ts
@@ -1,6 +1,8 @@
 import 'jest-extended';
 
 import { Config, ContentedProcessor } from './ContentedProcessor';
+import { MarkdownPipeline } from '@birthdayresearch/contented-pipeline-md';
+import { FileContent, FileIndex } from '@birthdayresearch/contented-pipeline';
 
 describe('process', () => {
   const config: Config = {
@@ -184,6 +186,44 @@ describe('build', () => {
           },
         ],
       },
+    });
+  });
+});
+
+describe('custom', function () {
+  class CustomPipeline extends MarkdownPipeline {
+    override async processFile(fileIndex: FileIndex): Promise<FileContent | undefined> {
+      return {
+        ...fileIndex,
+        html: '<div>CUSTOM</div>',
+        headings: [],
+      };
+    }
+  }
+
+  const config: Config = {
+    rootDir: './fixtures',
+    outDir: './.contented',
+    pipelines: [
+      {
+        type: 'Custom',
+        pattern: '**/*.md',
+        processor: CustomPipeline,
+      },
+    ],
+  };
+  const processor = new ContentedProcessor(config);
+
+  it('should use custom pipeline', async function () {
+    expect(await processor.process(':2:path-1.md')).toStrictEqual({
+      id: expect.stringMatching(/[0-f]{64}/),
+      modifiedDate: expect.any(Number),
+      type: 'Custom',
+      path: '/path-1',
+      sections: [],
+      fields: {},
+      html: '<div>CUSTOM</div>',
+      headings: [],
     });
   });
 });

--- a/packages/contented-processor/src/ContentedProcessor.unit.ts
+++ b/packages/contented-processor/src/ContentedProcessor.unit.ts
@@ -1,8 +1,9 @@
 import 'jest-extended';
 
-import { Config, ContentedProcessor } from './ContentedProcessor';
-import { MarkdownPipeline } from '@birthdayresearch/contented-pipeline-md';
 import { FileContent, FileIndex } from '@birthdayresearch/contented-pipeline';
+import { MarkdownPipeline } from '@birthdayresearch/contented-pipeline-md';
+
+import { Config, ContentedProcessor } from './ContentedProcessor';
 
 describe('process', () => {
   const config: Config = {
@@ -190,7 +191,7 @@ describe('build', () => {
   });
 });
 
-describe('custom', function () {
+describe('custom', () => {
   class CustomPipeline extends MarkdownPipeline {
     override async processFile(fileIndex: FileIndex): Promise<FileContent | undefined> {
       return {
@@ -214,7 +215,7 @@ describe('custom', function () {
   };
   const processor = new ContentedProcessor(config);
 
-  it('should use custom pipeline', async function () {
+  it('should use custom pipeline', async () => {
     expect(await processor.process(':2:path-1.md')).toStrictEqual({
       id: expect.stringMatching(/[0-f]{64}/),
       modifiedDate: expect.any(Number),


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows injection of custom `ContentedPipeline` into the processor field. 

```ts
  processor: 'md' | (new (pipeline: Pipeline) => ContentedPipeline);
```