### PR TITLE
refactor(contented-pipeline-md): refactor MarkdownPipeline for easier extendability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
+    "write": "turbo run write",
+    "watch": "turbo run watch",
+    "generate": "turbo run generate",
     "format": "prettier --write .",
     "lint": "turbo run lint -- --fix",
     "prepare": "husky install",


### PR DESCRIPTION
#### What this PR does / why we need it:

Refactor `MarkdownPipeline` to allow parts that you want to override to be easily overridable.