### PR TITLE
feat(contented-pipeline): allow Pipeline to generate multiple FileContent per file

### DIFF
--- a/packages/contented-pipeline-jest-md/src/JestMarkdownPipeline.unit.ts
+++ b/packages/contented-pipeline-jest-md/src/JestMarkdownPipeline.unit.ts
@@ -61,7 +61,7 @@ describe('JestMarkdownPipeline', () => {
     });
     // @contented codeblock:end
 
-    expect(content?.html).toStrictEqual(
+    expect(content[0]?.html).toStrictEqual(
       '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h2"><a class="toc-link toc-link-h2" href="#comments">Comments</a></li><li class="toc-item toc-item-h2"><a class="toc-link toc-link-h2" href="#contented-codeblock">@contented codeblock</a></li></ol></nav><p>This is an example of how to write Example Documentation with embedded codeblock!</p>\n' +
         '<h2 id="comments"><a aria-hidden="true" tabindex="-1" href="#comments"><span class="icon icon-link"></span></a>Comments</h2>\n' +
         '<p>All comments are automatically picked up.</p>\n' +
@@ -127,7 +127,7 @@ describe('@contented codeblock', () => {
   it('should pick up this codeblock', async () => {
     await pipeline.init();
     const content = await pipeline.process(__dirname, 'JestMarkdownPipeline.unit.ts');
-    expect(content?.html).toContain('should pick up this codeblock');
+    expect(content[0]?.html).toContain('should pick up this codeblock');
   });
 });
 // @contented codeblock:end

--- a/packages/contented-pipeline-jest-md/src/JestMarkdownPipeline.unit.ts
+++ b/packages/contented-pipeline-jest-md/src/JestMarkdownPipeline.unit.ts
@@ -36,29 +36,31 @@ describe('JestMarkdownPipeline', () => {
   it('should process JestMarkdownPipeline.unit.ts', async () => {
     // @contented codeblock:start
     const content = await pipeline.process(__dirname, 'JestMarkdownPipeline.unit.ts');
-    expect(content).toStrictEqual({
-      type: 'Example',
-      fields: {},
-      headings: [
-        {
-          children: [],
-          depth: 2,
-          id: 'comments',
-          title: 'Comments',
-        },
-        {
-          children: [],
-          depth: 2,
-          id: 'contented-codeblock',
-          title: '@contented codeblock',
-        },
-      ],
-      path: '/jest-markdown-pipeline',
-      sections: [],
-      id: expect.stringMatching(/[0-f]{64}/),
-      modifiedDate: expect.any(Number),
-      html: expect.any(String),
-    });
+    expect(content).toStrictEqual([
+      {
+        type: 'Example',
+        fields: {},
+        headings: [
+          {
+            children: [],
+            depth: 2,
+            id: 'comments',
+            title: 'Comments',
+          },
+          {
+            children: [],
+            depth: 2,
+            id: 'contented-codeblock',
+            title: '@contented codeblock',
+          },
+        ],
+        path: '/jest-markdown-pipeline',
+        sections: [],
+        id: expect.stringMatching(/[0-f]{64}/),
+        modifiedDate: expect.any(Number),
+        html: expect.any(String),
+      },
+    ]);
     // @contented codeblock:end
 
     expect(content[0]?.html).toStrictEqual(
@@ -76,29 +78,31 @@ describe('JestMarkdownPipeline', () => {
         '<h2 id="contented-codeblock"><a aria-hidden="true" tabindex="-1" href="#contented-codeblock"><span class="icon icon-link"></span></a><code>@contented codeblock</code></h2>\n' +
         '<p>This works</p>\n' +
         '<pre class="shiki" style="background-color: #22272e"><code><span class="line"><span style="color: #F47067">const</span><span style="color: #ADBAC7"> </span><span style="color: #6CB6FF">content</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">=</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">await</span><span style="color: #ADBAC7"> pipeline.</span><span style="color: #DCBDFB">process</span><span style="color: #ADBAC7">(__dirname, </span><span style="color: #96D0FF">\'JestMarkdownPipeline.unit.ts\'</span><span style="color: #ADBAC7">);</span></span>\n' +
-        '<span class="line"><span style="color: #DCBDFB">expect</span><span style="color: #ADBAC7">(content).</span><span style="color: #DCBDFB">toStrictEqual</span><span style="color: #ADBAC7">({</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  type: </span><span style="color: #96D0FF">\'Example\'</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  fields: {},</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  headings: [</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">    {</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      children: [],</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      depth: </span><span style="color: #6CB6FF">2</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      id: </span><span style="color: #96D0FF">\'comments\'</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      title: </span><span style="color: #96D0FF">\'Comments\'</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">    },</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">    {</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      children: [],</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      depth: </span><span style="color: #6CB6FF">2</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      id: </span><span style="color: #96D0FF">\'contented-codeblock\'</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">      title: </span><span style="color: #96D0FF">\'@contented codeblock\'</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">    },</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  ],</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  path: </span><span style="color: #96D0FF">\'/jest-markdown-pipeline\'</span><span style="color: #ADBAC7">,</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  sections: [],</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  id: expect.</span><span style="color: #DCBDFB">stringMatching</span><span style="color: #ADBAC7">(</span><span style="color: #96D0FF">/</span><span style="color: #6CB6FF">[0-f]</span><span style="color: #F47067">{64}</span><span style="color: #96D0FF">/</span><span style="color: #ADBAC7">),</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  modifiedDate: expect.</span><span style="color: #DCBDFB">any</span><span style="color: #ADBAC7">(</span><span style="color: #6CB6FF">Number</span><span style="color: #ADBAC7">),</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  html: expect.</span><span style="color: #DCBDFB">any</span><span style="color: #ADBAC7">(</span><span style="color: #6CB6FF">String</span><span style="color: #ADBAC7">),</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">});</span></span></code></pre>\n' +
+        '<span class="line"><span style="color: #DCBDFB">expect</span><span style="color: #ADBAC7">(content).</span><span style="color: #DCBDFB">toStrictEqual</span><span style="color: #ADBAC7">([</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">  {</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    type: </span><span style="color: #96D0FF">\'Example\'</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    fields: {},</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    headings: [</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">      {</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        children: [],</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        depth: </span><span style="color: #6CB6FF">2</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        id: </span><span style="color: #96D0FF">\'comments\'</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        title: </span><span style="color: #96D0FF">\'Comments\'</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">      },</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">      {</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        children: [],</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        depth: </span><span style="color: #6CB6FF">2</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        id: </span><span style="color: #96D0FF">\'contented-codeblock\'</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">        title: </span><span style="color: #96D0FF">\'@contented codeblock\'</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">      },</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    ],</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    path: </span><span style="color: #96D0FF">\'/jest-markdown-pipeline\'</span><span style="color: #ADBAC7">,</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    sections: [],</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    id: expect.</span><span style="color: #DCBDFB">stringMatching</span><span style="color: #ADBAC7">(</span><span style="color: #96D0FF">/</span><span style="color: #6CB6FF">[0-f]</span><span style="color: #F47067">{64}</span><span style="color: #96D0FF">/</span><span style="color: #ADBAC7">),</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    modifiedDate: expect.</span><span style="color: #DCBDFB">any</span><span style="color: #ADBAC7">(</span><span style="color: #6CB6FF">Number</span><span style="color: #ADBAC7">),</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    html: expect.</span><span style="color: #DCBDFB">any</span><span style="color: #ADBAC7">(</span><span style="color: #6CB6FF">String</span><span style="color: #ADBAC7">),</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">  },</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">]);</span></span></code></pre>\n' +
         '<pre class="shiki" style="background-color: #22272e"><code><span class="line"><span style="color: #DCBDFB">describe</span><span style="color: #ADBAC7">(</span><span style="color: #96D0FF">\'@contented codeblock\'</span><span style="color: #ADBAC7">, () </span><span style="color: #F47067">=></span><span style="color: #ADBAC7"> {</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">  </span><span style="color: #F47067">const</span><span style="color: #ADBAC7"> </span><span style="color: #6CB6FF">pipeline</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">=</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">new</span><span style="color: #ADBAC7"> </span><span style="color: #DCBDFB">JestMarkdownPipeline</span><span style="color: #ADBAC7">({</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">    type: </span><span style="color: #96D0FF">\'Example\'</span><span style="color: #ADBAC7">,</span></span>\n' +
@@ -109,7 +113,7 @@ describe('JestMarkdownPipeline', () => {
         '<span class="line"><span style="color: #ADBAC7">  </span><span style="color: #DCBDFB">it</span><span style="color: #ADBAC7">(</span><span style="color: #96D0FF">\'should pick up this codeblock\'</span><span style="color: #ADBAC7">, </span><span style="color: #F47067">async</span><span style="color: #ADBAC7"> () </span><span style="color: #F47067">=></span><span style="color: #ADBAC7"> {</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">    </span><span style="color: #F47067">await</span><span style="color: #ADBAC7"> pipeline.</span><span style="color: #DCBDFB">init</span><span style="color: #ADBAC7">();</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">    </span><span style="color: #F47067">const</span><span style="color: #ADBAC7"> </span><span style="color: #6CB6FF">content</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">=</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">await</span><span style="color: #ADBAC7"> pipeline.</span><span style="color: #DCBDFB">process</span><span style="color: #ADBAC7">(__dirname, </span><span style="color: #96D0FF">\'JestMarkdownPipeline.unit.ts\'</span><span style="color: #ADBAC7">);</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">    </span><span style="color: #DCBDFB">expect</span><span style="color: #ADBAC7">(content?.html).</span><span style="color: #DCBDFB">toContain</span><span style="color: #ADBAC7">(</span><span style="color: #96D0FF">\'should pick up this codeblock\'</span><span style="color: #ADBAC7">);</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">    </span><span style="color: #DCBDFB">expect</span><span style="color: #ADBAC7">(content[</span><span style="color: #6CB6FF">0</span><span style="color: #ADBAC7">]?.html).</span><span style="color: #DCBDFB">toContain</span><span style="color: #ADBAC7">(</span><span style="color: #96D0FF">\'should pick up this codeblock\'</span><span style="color: #ADBAC7">);</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">  });</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">});</span></span></code></pre>',
     );

--- a/packages/contented-pipeline-md/src/MarkdownPipeline.ts
+++ b/packages/contented-pipeline-md/src/MarkdownPipeline.ts
@@ -15,14 +15,14 @@ export class MarkdownPipeline extends ContentedPipeline {
     await initProcessor(this.processor);
   }
 
-  protected override async processFile(
+  protected override async processFileIndex(
     fileIndex: FileIndex,
     rootPath: string,
     file: string,
-  ): Promise<FileContent | undefined> {
+  ): Promise<FileContent[]> {
     const vFile = await this.readVFile(rootPath, file);
     if (vFile === undefined) {
-      return undefined;
+      return [];
     }
 
     vFile.data = { contented: this.newUnifiedContented() };
@@ -32,10 +32,11 @@ export class MarkdownPipeline extends ContentedPipeline {
     if (contented.errors.length > 0) {
       const message = contented.errors.map((value) => `${value.type}:${value.reason}`).join(',');
       console.warn(`@birthdayresearch/contented-pipeline-md: ${file} - failed with errors: [${message}]`);
-      return undefined;
+      return [];
     }
 
-    return this.newFileContent(fileIndex, output.value as string, contented);
+    const content = this.newFileContent(fileIndex, output.value as string, contented);
+    return [content];
   }
 
   protected async readVFile(rootPath: string, file: string): Promise<VFile | undefined> {

--- a/packages/contented-pipeline-md/src/MarkdownPipeline.unit.ts
+++ b/packages/contented-pipeline-md/src/MarkdownPipeline.unit.ts
@@ -17,22 +17,24 @@ describe('Without Config', () => {
 
   it('should process See.Nothing.md', async () => {
     const content = await pipeline.process(rootPath, 'See.Nothing.md');
-    expect(content).toStrictEqual({
-      type: 'Markdown',
-      fields: {},
-      headings: [
-        {
-          depth: 1,
-          id: 'nothing-to-see',
-          title: 'Nothing To See',
-          children: [],
-        },
-      ],
-      path: '/see-nothing',
-      sections: [],
-      id: expect.stringMatching(/[0-f]{64}/),
-      modifiedDate: expect.any(Number),
-      html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#nothing-to-see">Nothing To See</a></li></ol></nav><h1 id="nothing-to-see"><a aria-hidden="true" tabindex="-1" href="#nothing-to-see"><span class="icon icon-link"></span></a>Nothing To See</h1>\n<p>Markdown for testing <code>MarkdownPipeline.unit.ts</code>.</p>',
-    });
+    expect(content).toStrictEqual([
+      {
+        type: 'Markdown',
+        fields: {},
+        headings: [
+          {
+            depth: 1,
+            id: 'nothing-to-see',
+            title: 'Nothing To See',
+            children: [],
+          },
+        ],
+        path: '/see-nothing',
+        sections: [],
+        id: expect.stringMatching(/[0-f]{64}/),
+        modifiedDate: expect.any(Number),
+        html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#nothing-to-see">Nothing To See</a></li></ol></nav><h1 id="nothing-to-see"><a aria-hidden="true" tabindex="-1" href="#nothing-to-see"><span class="icon icon-link"></span></a>Nothing To See</h1>\n<p>Markdown for testing <code>MarkdownPipeline.unit.ts</code>.</p>',
+      },
+    ]);
   });
 });

--- a/packages/contented-pipeline/src/Pipeline.ts
+++ b/packages/contented-pipeline/src/Pipeline.ts
@@ -32,23 +32,24 @@ export abstract class ContentedPipeline {
    */
   async init(): Promise<void> {} // eslint-disable-line @typescript-eslint/no-empty-function
 
-  async process(rootPath: string, file: string): Promise<FileContent | undefined> {
+  /**
+   * @param {string} rootPath
+   * @param {string} file to process
+   * @return {FileContent[]} containing none, one or many FileContent
+   */
+  async process(rootPath: string, file: string): Promise<FileContent[]> {
     const fileIndex = await this.newFileIndex(rootPath, file);
-    const content = await this.processFile(fileIndex, rootPath, file);
-    if (content === undefined) {
-      return undefined;
+    const contents = await this.processFileIndex(fileIndex, rootPath, file);
+    if (contents === undefined) {
+      return [];
     }
     if (this.pipeline.transform === undefined) {
-      return content;
+      return contents;
     }
-    return this.pipeline.transform(content);
+    return Promise.all(contents.map(this.pipeline.transform));
   }
 
-  protected abstract processFile(
-    fileIndex: FileIndex,
-    rootPath: string,
-    file: string,
-  ): Promise<FileContent | undefined>;
+  protected abstract processFileIndex(fileIndex: FileIndex, rootPath: string, file: string): Promise<FileContent[]>;
 
   get type() {
     return this.pipeline.type;

--- a/packages/contented-pipeline/src/Pipeline.unit.ts
+++ b/packages/contented-pipeline/src/Pipeline.unit.ts
@@ -2,8 +2,8 @@ import { ContentedPipeline } from './Pipeline';
 import { FileContent } from './PipelineFile';
 
 class TestPipeline extends ContentedPipeline {
-  processFile(): Promise<FileContent | undefined> {
-    return Promise.resolve(undefined);
+  processFileIndex(): Promise<FileContent[]> {
+    return Promise.resolve([]);
   }
 }
 

--- a/packages/contented-processor/src/ContentedProcessor.unit.ts
+++ b/packages/contented-processor/src/ContentedProcessor.unit.ts
@@ -21,76 +21,84 @@ describe('process', () => {
   const processor = new ContentedProcessor(config);
 
   it('should process Foo.Bar.md', async () => {
-    expect(await processor.process('Foo.Bar.md')).toStrictEqual({
-      type: 'Markdown',
-      fields: {},
-      headings: [
-        {
-          children: [],
-          depth: 1,
-          id: 'what-is-going-on',
-          title: 'What is going on',
-        },
-      ],
-      path: '/foo-bar',
-      sections: [],
-      id: expect.stringMatching(/[0-f]{64}/),
-      modifiedDate: expect.any(Number),
-      html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#what-is-going-on">What is going on</a></li></ol></nav><h1 id="what-is-going-on"><a aria-hidden="true" tabindex="-1" href="#what-is-going-on"><span class="icon icon-link"></span></a>What is going on</h1>\n<p>Markdown for testing <code>ContentedProcessor.unit.ts</code>.</p>',
-    });
+    expect(await processor.process('Foo.Bar.md')).toStrictEqual([
+      {
+        type: 'Markdown',
+        fields: {},
+        headings: [
+          {
+            children: [],
+            depth: 1,
+            id: 'what-is-going-on',
+            title: 'What is going on',
+          },
+        ],
+        path: '/foo-bar',
+        sections: [],
+        id: expect.stringMatching(/[0-f]{64}/),
+        modifiedDate: expect.any(Number),
+        html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#what-is-going-on">What is going on</a></li></ol></nav><h1 id="what-is-going-on"><a aria-hidden="true" tabindex="-1" href="#what-is-going-on"><span class="icon icon-link"></span></a>What is going on</h1>\n<p>Markdown for testing <code>ContentedProcessor.unit.ts</code>.</p>',
+      },
+    ]);
   });
 
   it('should process :2:path-1.md', async () => {
-    expect(await processor.process(':2:path-1.md')).toStrictEqual({
-      type: 'Markdown',
-      fields: {},
-      headings: [],
-      path: '/path-1',
-      sections: [],
-      id: expect.stringMatching(/[0-f]{64}/),
-      modifiedDate: expect.any(Number),
-      html: '<nav class="toc"><ol class="toc-level toc-level-1"></ol></nav><p>Title</p>',
-    });
+    expect(await processor.process(':2:path-1.md')).toStrictEqual([
+      {
+        type: 'Markdown',
+        fields: {},
+        headings: [],
+        path: '/path-1',
+        sections: [],
+        id: expect.stringMatching(/[0-f]{64}/),
+        modifiedDate: expect.any(Number),
+        html: '<nav class="toc"><ol class="toc-level toc-level-1"></ol></nav><p>Title</p>',
+      },
+    ]);
   });
 
   it('should process :1:Category/:1:slug.md', async () => {
-    expect(await processor.process(':1:Category/:1:slug.md')).toStrictEqual({
-      type: 'Markdown',
-      fields: {},
-      headings: [
-        {
-          children: [],
-          depth: 2,
-          id: 'header',
-          title: 'Header',
-        },
-      ],
-      path: '/category/slug',
-      sections: ['Category'],
-      id: expect.stringMatching(/[0-f]{64}/),
-      modifiedDate: expect.any(Number),
-      html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h2"><a class="toc-link toc-link-h2" href="#header">Header</a></li></ol></nav><h2 id="header"><a aria-hidden="true" tabindex="-1" href="#header"><span class="icon icon-link"></span></a>Header</h2>\n<p>Content</p>',
-    });
+    expect(await processor.process(':1:Category/:1:slug.md')).toStrictEqual([
+      {
+        type: 'Markdown',
+        fields: {},
+        headings: [
+          {
+            children: [],
+            depth: 2,
+            id: 'header',
+            title: 'Header',
+          },
+        ],
+        path: '/category/slug',
+        sections: ['Category'],
+        id: expect.stringMatching(/[0-f]{64}/),
+        modifiedDate: expect.any(Number),
+        html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h2"><a class="toc-link toc-link-h2" href="#header">Header</a></li></ol></nav><h2 id="header"><a aria-hidden="true" tabindex="-1" href="#header"><span class="icon icon-link"></span></a>Header</h2>\n<p>Content</p>',
+      },
+    ]);
   });
 
   it('should process :1:Category/Section/:2:path.md', async () => {
-    expect(await processor.process(':1:Category/Section/:2:path.md')).toStrictEqual({
-      type: 'Markdown',
-      fields: {},
-      headings: [
-        {
-          children: [],
-          depth: 2,
-          id: 'header',
-          title: 'Header',
-        },
-      ],
-      html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h2"><a class="toc-link toc-link-h2" href="#header">Header</a></li></ol></nav><h2 id="header"><a aria-hidden="true" tabindex="-1" href="#header"><span class="icon icon-link"></span></a>Header</h2>\n<p>Content</p>',
-      id: expect.stringMatching(/[0-f]{64}/),
-      modifiedDate: expect.any(Number),
-      sections: ['Category', 'Section'],
-      path: '/category/section/path',
-    });
+    expect(await processor.process(':1:Category/Section/:2:path.md')).toStrictEqual([
+      {
+        type: 'Markdown',
+        fields: {},
+        headings: [
+          {
+            children: [],
+            depth: 2,
+            id: 'header',
+            title: 'Header',
+          },
+        ],
+        html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h2"><a class="toc-link toc-link-h2" href="#header">Header</a></li></ol></nav><h2 id="header"><a aria-hidden="true" tabindex="-1" href="#header"><span class="icon icon-link"></span></a>Header</h2>\n<p>Content</p>',
+        id: expect.stringMatching(/[0-f]{64}/),
+        modifiedDate: expect.any(Number),
+        sections: ['Category', 'Section'],
+        path: '/category/section/path',
+      },
+    ]);
   });
 });
 
@@ -193,12 +201,14 @@ describe('build', () => {
 
 describe('custom', () => {
   class CustomPipeline extends MarkdownPipeline {
-    override async processFile(fileIndex: FileIndex): Promise<FileContent | undefined> {
-      return {
-        ...fileIndex,
-        html: '<div>CUSTOM</div>',
-        headings: [],
-      };
+    override async processFileIndex(fileIndex: FileIndex): Promise<FileContent[]> {
+      return [
+        {
+          ...fileIndex,
+          html: '<div>CUSTOM</div>',
+          headings: [],
+        },
+      ];
     }
   }
 
@@ -216,16 +226,18 @@ describe('custom', () => {
   const processor = new ContentedProcessor(config);
 
   it('should use custom pipeline', async () => {
-    expect(await processor.process(':2:path-1.md')).toStrictEqual({
-      id: expect.stringMatching(/[0-f]{64}/),
-      modifiedDate: expect.any(Number),
-      type: 'Custom',
-      path: '/path-1',
-      sections: [],
-      fields: {},
-      html: '<div>CUSTOM</div>',
-      headings: [],
-    });
+    expect(await processor.process(':2:path-1.md')).toStrictEqual([
+      {
+        id: expect.stringMatching(/[0-f]{64}/),
+        modifiedDate: expect.any(Number),
+        type: 'Custom',
+        path: '/path-1',
+        sections: [],
+        fields: {},
+        html: '<div>CUSTOM</div>',
+        headings: [],
+      },
+    ]);
   });
 });
 

--- a/packages/contented/src/commands/WriteCommand.ts
+++ b/packages/contented/src/commands/WriteCommand.ts
@@ -11,7 +11,7 @@ export class WriteCommand extends WatchCommand {
     const processor = new ContentedProcessor(config.processor);
 
     await this.walk(processor);
-    await this.subscribe(processor);
+    await this.watch(processor);
 
     const preview = new ContentedPreview(config.preview);
     await preview.init();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Refactor Pipeline to allow `process()` to return multiple FileContent per input file.
