### PR TITLE
chore(contented-pipeline): inject rootPath into ContentedPipeline

### DIFF
--- a/packages/contented-pipeline-jest-md/src/JestMarkdownPipeline.unit.ts
+++ b/packages/contented-pipeline-jest-md/src/JestMarkdownPipeline.unit.ts
@@ -17,7 +17,7 @@ import { JestMarkdownPipeline } from './JestMarkdownPipeline.js';
  */
 describe('JestMarkdownPipeline', () => {
   // @contented codeblock:start
-  const pipeline = new JestMarkdownPipeline({
+  const pipeline = new JestMarkdownPipeline(__dirname, {
     type: 'Example',
     pattern: '**/*.unit.ts',
     processor: JestMarkdownPipeline,
@@ -69,7 +69,7 @@ describe('JestMarkdownPipeline', () => {
         '<p>All comments are automatically picked up.</p>\n' +
         '<pre class="shiki" style="background-color: #22272e"><code><span class="line"></span></code></pre>\n' +
         '<p>Natural flow of content and tests.</p>\n' +
-        '<pre class="shiki" style="background-color: #22272e"><code><span class="line"><span style="color: #F47067">const</span><span style="color: #ADBAC7"> </span><span style="color: #6CB6FF">pipeline</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">=</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">new</span><span style="color: #ADBAC7"> </span><span style="color: #DCBDFB">JestMarkdownPipeline</span><span style="color: #ADBAC7">({</span></span>\n' +
+        '<pre class="shiki" style="background-color: #22272e"><code><span class="line"><span style="color: #F47067">const</span><span style="color: #ADBAC7"> </span><span style="color: #6CB6FF">pipeline</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">=</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">new</span><span style="color: #ADBAC7"> </span><span style="color: #DCBDFB">JestMarkdownPipeline</span><span style="color: #ADBAC7">(__dirname, {</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">  type: </span><span style="color: #96D0FF">\'Example\'</span><span style="color: #ADBAC7">,</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">  pattern: </span><span style="color: #96D0FF">\'**/*.unit.ts\'</span><span style="color: #ADBAC7">,</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">  processor: JestMarkdownPipeline,</span></span>\n' +
@@ -104,7 +104,7 @@ describe('JestMarkdownPipeline', () => {
         '<span class="line"><span style="color: #ADBAC7">  },</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">]);</span></span></code></pre>\n' +
         '<pre class="shiki" style="background-color: #22272e"><code><span class="line"><span style="color: #DCBDFB">describe</span><span style="color: #ADBAC7">(</span><span style="color: #96D0FF">\'@contented codeblock\'</span><span style="color: #ADBAC7">, () </span><span style="color: #F47067">=></span><span style="color: #ADBAC7"> {</span></span>\n' +
-        '<span class="line"><span style="color: #ADBAC7">  </span><span style="color: #F47067">const</span><span style="color: #ADBAC7"> </span><span style="color: #6CB6FF">pipeline</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">=</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">new</span><span style="color: #ADBAC7"> </span><span style="color: #DCBDFB">JestMarkdownPipeline</span><span style="color: #ADBAC7">({</span></span>\n' +
+        '<span class="line"><span style="color: #ADBAC7">  </span><span style="color: #F47067">const</span><span style="color: #ADBAC7"> </span><span style="color: #6CB6FF">pipeline</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">=</span><span style="color: #ADBAC7"> </span><span style="color: #F47067">new</span><span style="color: #ADBAC7"> </span><span style="color: #DCBDFB">JestMarkdownPipeline</span><span style="color: #ADBAC7">(__dirname, {</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">    type: </span><span style="color: #96D0FF">\'Example\'</span><span style="color: #ADBAC7">,</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">    pattern: </span><span style="color: #96D0FF">\'**/*.unit.ts\'</span><span style="color: #ADBAC7">,</span></span>\n' +
         '<span class="line"><span style="color: #ADBAC7">    processor: JestMarkdownPipeline,</span></span>\n' +
@@ -122,7 +122,7 @@ describe('JestMarkdownPipeline', () => {
 
 // @contented codeblock:start
 describe('@contented codeblock', () => {
-  const pipeline = new JestMarkdownPipeline({
+  const pipeline = new JestMarkdownPipeline(__dirname, {
     type: 'Example',
     pattern: '**/*.unit.ts',
     processor: JestMarkdownPipeline,

--- a/packages/contented-pipeline-md/src/MarkdownPipeline.unit.ts
+++ b/packages/contented-pipeline-md/src/MarkdownPipeline.unit.ts
@@ -5,7 +5,7 @@ import { MarkdownPipeline } from './MarkdownPipeline';
 const rootPath = join(__dirname, '../fixtures');
 
 describe('Without Config', () => {
-  const pipeline = new MarkdownPipeline({
+  const pipeline = new MarkdownPipeline(__dirname, {
     type: 'Markdown',
     pattern: '**/*.md',
     processor: 'md',

--- a/packages/contented-pipeline/src/Pipeline.ts
+++ b/packages/contented-pipeline/src/Pipeline.ts
@@ -13,7 +13,7 @@ export interface Pipeline {
    * Built in processor: 'md'
    * Otherwise it will `import(processor)` module with default exporting ContentedPipeline
    */
-  processor: 'md' | 'jest-md' | (new (pipeline: Pipeline) => ContentedPipeline);
+  processor: 'md' | 'jest-md' | (new (rootPath: string, pipeline: Pipeline) => ContentedPipeline);
   fields?: {
     [name: string]: PipelineField;
   };
@@ -25,7 +25,7 @@ export interface Pipeline {
  * Contented Pipeline (Path-based)
  */
 export abstract class ContentedPipeline {
-  public constructor(protected readonly pipeline: Pipeline) {}
+  public constructor(protected readonly rootPath: string, protected readonly pipeline: Pipeline) {}
 
   /**
    * Optional init for Pipeline that require async setup.

--- a/packages/contented-pipeline/src/Pipeline.unit.ts
+++ b/packages/contented-pipeline/src/Pipeline.unit.ts
@@ -8,7 +8,7 @@ class TestPipeline extends ContentedPipeline {
 }
 
 it('should be extendable', async () => {
-  const pipeline = new TestPipeline({
+  const pipeline = new TestPipeline(__dirname, {
     type: 'Type',
     pattern: '**/*.md',
     processor: 'md',

--- a/packages/contented-processor/src/ContentedProcessor.ts
+++ b/packages/contented-processor/src/ContentedProcessor.ts
@@ -112,12 +112,12 @@ export class ContentedProcessor {
     const newPipeline = (): ContentedPipeline => {
       switch (pipeline.processor) {
         case 'md':
-          return new MarkdownPipeline(pipeline);
+          return new MarkdownPipeline(this.rootPath, pipeline);
         case 'jest-md':
-          return new JestMarkdownPipeline(pipeline);
+          return new JestMarkdownPipeline(this.rootPath, pipeline);
         default:
           // eslint-disable-next-line new-cap
-          return new pipeline.processor(pipeline);
+          return new pipeline.processor(this.rootPath, pipeline);
       }
     };
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

As per the title, allows customized ContentedPipeline to have access to `rootPath` to know where is the project root is at.