### PR TITLE
chore(contented): ContentedWatcher now uses glob pattern ignore

### DIFF
--- a/packages/contented/src/commands/contented/ContentedWatcher.ts
+++ b/packages/contented/src/commands/contented/ContentedWatcher.ts
@@ -16,7 +16,7 @@ export class ContentedWatcher extends ContentedWalker {
     const dotContentedDir = join(relative(this.processor.rootPath, process.cwd()), '.contented');
     const callback = (err: Error | null, events: Event[]) => this.listen(events);
     await watcher.subscribe(this.processor.rootPath, callback, {
-      ignore: [dotContentedDir, '.contented', 'node_modules', '.git', '.idea', '.vscode'],
+      ignore: [dotContentedDir, '**/.contented', '**/node_modules', '**/.turbo', '.git', '.idea', '.vscode'],
     });
   }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `**/.contented`, `**/node_modules`, and `**/.turbo` for glob pattern ignore.

Introduced in `@parcel/watcher` `2.1.0` — https://github.com/BirthdayResearch/contented/pull/302