### PR TITLE
chore(workflow): replace all node-version with node-version-file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - run: npm ci
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - run: npm ci
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - run: npm ci
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16
+          node-version-file: '.nvmrc'
           cache: npm
 
       - run: npm ci
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16
+          node-version-file: '.nvmrc'
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,10 @@ jobs:
     environment: NPM Release
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
 
       - run: npm ci
 


### PR DESCRIPTION
#### What this PR does / why we need it:

`.nvmrc` is now the source of truth for node version.