### PR TITLE
chore(contented-preview): throw verbose error for undefined collections

### DIFF
--- a/packages/contented-preview/src/errors/PipelineCollectionNotFoundException.js
+++ b/packages/contented-preview/src/errors/PipelineCollectionNotFoundException.js
@@ -1,0 +1,5 @@
+export class PipelineCollectionNotFoundException extends Error {
+  constructor(pipelineName){
+    super(`Pipeline type '${pipelineName}' cannot resolve its collection. Please check if contented.config.js is properly configured.`)
+  }
+}

--- a/packages/contented-preview/src/pages/_components/Header.jsx
+++ b/packages/contented-preview/src/pages/_components/Header.jsx
@@ -1,10 +1,11 @@
-import { DocumentTextIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
-
-import { useMenu } from './MenuContext';
-import ThemeButton from './ThemeButton';
-import { Pipelines } from '../../../../index.js';
+import { Bars3Icon, DocumentTextIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import clsx from 'clsx';
 import Link from 'next/link';
+
+import { Pipelines } from '../../../../index.js';
+import { PipelineCollectionNotFoundException } from '../../errors/PipelineCollectionNotFoundException.js';
+import { useMenu } from './MenuContext';
+import ThemeButton from './ThemeButton';
 
 export default function Header() {
   const { isOpen, setIsOpen } = useMenu();
@@ -35,6 +36,9 @@ export default function Header() {
             {pipelines.length > 1 && (
               <div className="ml-6 flex border-l border-slate-300/60 pl-4 dark:border-slate-300/10">
                 {pipelines.map(([type, pipeline]) => {
+                  if (pipeline.collection[0] === undefined || pipeline.collection[0] === null) {
+                    throw new PipelineCollectionNotFoundException(type);
+                  }
                   return (
                     <Link href={pipeline.collection[0].path} key={type}>
                       <div


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Better developer experience when encountering incorrect configuration for pipelines when using contented.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #318

#### Additional comments?:

In the long run, maybe something that checks the `contented.config.js` file and shows the error before even attempting to preview would be an even better experience.