### PR TITLE
chore(contented-preview): remove @tailwindcss/line-clamp plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4415,14 +4415,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
-      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
-      "peerDependencies": {
-        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
-      }
-    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
@@ -20086,7 +20078,6 @@
       "dependencies": {
         "@headlessui/react": "1.7.14",
         "@heroicons/react": "2.0.17",
-        "@tailwindcss/line-clamp": "0.4.4",
         "@tailwindcss/typography": "0.5.9",
         "autoprefixer": "10.4.14",
         "clsx": "1.2.1",

--- a/packages/contented-preview/package.json
+++ b/packages/contented-preview/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@headlessui/react": "1.7.14",
     "@heroicons/react": "2.0.17",
-    "@tailwindcss/line-clamp": "0.4.4",
     "@tailwindcss/typography": "0.5.9",
     "autoprefixer": "10.4.14",
     "clsx": "1.2.1",

--- a/packages/contented-preview/tailwind.config.js
+++ b/packages/contented-preview/tailwind.config.js
@@ -41,5 +41,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require('@tailwindcss/line-clamp'), require('@tailwindcss/typography')],
+  plugins: [require('@tailwindcss/typography')],
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

As per tailwind `v3.3` this plugin is included by default.
