### PR TITLE
feat(contented-pipeline): parse the first heading as title when no title are present

### DIFF
--- a/packages/contented-pipeline-md/src/MarkdownPipeline.unit.ts
+++ b/packages/contented-pipeline-md/src/MarkdownPipeline.unit.ts
@@ -22,7 +22,7 @@ describe('Without Config', () => {
         type: 'Markdown',
         fields: {
           description: undefined,
-          title: undefined,
+          title: 'Nothing To See',
         },
         headings: [
           {

--- a/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.ts
+++ b/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.ts
@@ -1,9 +1,9 @@
-import { getInnerText } from '@jsdevtools/rehype-toc/lib/get-inner-text';
 import yaml from 'js-yaml';
 import { Parent } from 'mdast';
 import { Transformer } from 'unified';
 import { visit } from 'unist-util-visit';
 import { VFile } from 'vfile';
+import { toString } from 'mdast-util-to-string';
 
 import { UnifiedContented } from './Plugin.js';
 
@@ -27,7 +27,7 @@ function collectTitle(file: VFile): (node: { type: 'heading'; children: object[]
       return;
     }
 
-    contented.fields.title = getInnerText(node);
+    contented.fields.title = toString(node);
   };
 }
 

--- a/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.ts
+++ b/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.ts
@@ -1,6 +1,9 @@
+import { getInnerText } from '@jsdevtools/rehype-toc/lib/get-inner-text';
 import yaml from 'js-yaml';
 import { Parent } from 'mdast';
 import { Transformer } from 'unified';
+import { visit } from 'unist-util-visit';
+import { VFile } from 'vfile';
 
 import { UnifiedContented } from './Plugin.js';
 
@@ -11,6 +14,20 @@ export function collectFields(): Transformer<Parent> {
       const contented = file.data.contented as UnifiedContented;
       contented.fields = yaml.load(node.value) as any;
     }
+
+    visit(tree, 'heading', collectTitle(file));
+  };
+}
+
+function collectTitle(file: VFile): (node: { type: 'heading'; children: object[] }) => void {
+  const contented = file.data?.contented as UnifiedContented;
+
+  return (node) => {
+    if (contented.fields.title) {
+      return;
+    }
+
+    contented.fields.title = getInnerText(node);
   };
 }
 

--- a/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.ts
+++ b/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.ts
@@ -1,9 +1,9 @@
 import yaml from 'js-yaml';
 import { Parent } from 'mdast';
+import { toString } from 'mdast-util-to-string';
 import { Transformer } from 'unified';
 import { visit } from 'unist-util-visit';
 import { VFile } from 'vfile';
-import { toString } from 'mdast-util-to-string';
 
 import { UnifiedContented } from './Plugin.js';
 

--- a/packages/contented-processor/fixtures/Foo.Bar.md
+++ b/packages/contented-processor/fixtures/Foo.Bar.md
@@ -1,3 +1,5 @@
 # What is going on
 
+# Multiple title but take the first one
+
 Markdown for testing `ContentedProcessor.unit.ts`.

--- a/packages/contented-processor/src/ContentedProcessor.unit.ts
+++ b/packages/contented-processor/src/ContentedProcessor.unit.ts
@@ -27,7 +27,7 @@ describe('process', () => {
         type: 'Markdown',
         fields: {
           description: undefined,
-          title: undefined,
+          title: 'What is going on',
         },
         headings: [
           {
@@ -186,6 +186,17 @@ describe('build', () => {
             id: expect.stringMatching(/[0-f]{64}/),
             modifiedDate: expect.any(Number),
             path: '/path-1',
+            sections: [],
+            type: 'Markdown',
+          },
+          {
+            fields: {
+              title: 'What is going on',
+              description: undefined,
+            },
+            id: expect.stringMatching(/[0-f]{64}/),
+            modifiedDate: expect.any(Number),
+            path: '/foo-bar',
             sections: [],
             type: 'Markdown',
           },

--- a/packages/contented-processor/src/ContentedProcessor.unit.ts
+++ b/packages/contented-processor/src/ContentedProcessor.unit.ts
@@ -36,12 +36,18 @@ describe('process', () => {
             id: 'what-is-going-on',
             title: 'What is going on',
           },
+          {
+            children: [],
+            depth: 1,
+            id: 'multiple-title-but-take-the-first-one',
+            title: 'Multiple title but take the first one',
+          },
         ],
         path: '/foo-bar',
         sections: [],
         id: expect.stringMatching(/[0-f]{64}/),
         modifiedDate: expect.any(Number),
-        html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#what-is-going-on">What is going on</a></li></ol></nav><h1 id="what-is-going-on"><a aria-hidden="true" tabindex="-1" href="#what-is-going-on"><span class="icon icon-link"></span></a>What is going on</h1>\n<p>Markdown for testing <code>ContentedProcessor.unit.ts</code>.</p>',
+        html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#what-is-going-on">What is going on</a></li><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#multiple-title-but-take-the-first-one">Multiple title but take the first one</a></li></ol></nav><h1 id="what-is-going-on"><a aria-hidden="true" tabindex="-1" href="#what-is-going-on"><span class="icon icon-link"></span></a>What is going on</h1>\n<h1 id="multiple-title-but-take-the-first-one"><a aria-hidden="true" tabindex="-1" href="#multiple-title-but-take-the-first-one"><span class="icon icon-link"></span></a>Multiple title but take the first one</h1>\n<p>Markdown for testing <code>ContentedProcessor.unit.ts</code>.</p>',
       },
     ]);
   });


### PR DESCRIPTION
#### What this PR does / why we need it:

Parse the first heading as title when no title are present, this keep authoring more natural, not all MD requires frontmatter.

#### Which issue(s) does this PR fixes?:

Fixes #397
