### PR TITLE
feat(contented): title should be part of the docs

### DIFF
--- a/packages/contented-example/contented-example-lorem/[0]lorem-1.md
+++ b/packages/contented-example/contented-example-lorem/[0]lorem-1.md
@@ -1,6 +1,4 @@
----
-title: Lorem 1
----
+# Lorem 1
 
 > This is an example to create another pipeline.
 

--- a/packages/contented-example/contented-example-lorem/[1]lorem-2.md
+++ b/packages/contented-example/contented-example-lorem/[1]lorem-2.md
@@ -1,6 +1,4 @@
----
-title: Lorem 2
----
+# Lorem 2
 
 # Lacrimas dextras inornatos clipeum regina
 

--- a/packages/contented-example/contented.config.js
+++ b/packages/contented-example/contented.config.js
@@ -18,8 +18,6 @@ const config = {
         fields: {
           title: {
             type: 'string',
-            required: true,
-            resolve: (s) => s ?? 'Contented',
           },
           description: {
             type: 'string',

--- a/packages/contented-example/docs/01-index.md
+++ b/packages/contented-example/docs/01-index.md
@@ -1,3 +1,5 @@
+# Contented
+
 [Contented](https://contented.dev) is a Markdown-based authoring workflow that encourage developer authoring within
 its contextual Git repository. `npm i @birthdayresearch/contented`
 

--- a/packages/contented-example/docs/03-api.md
+++ b/packages/contented-example/docs/03-api.md
@@ -1,6 +1,4 @@
----
-title: API Reference
----
+# API Reference
 
 ## Contented CLI
 

--- a/packages/contented-example/docs/04-markdown.md
+++ b/packages/contented-example/docs/04-markdown.md
@@ -1,8 +1,9 @@
 ---
-title: Markdown Features
 description: The dialect of Markdown that is currently supported for contented
 tags: ['Markdown', 'Frontmatter', 'Admonitions', 'Mermaid']
 ---
+
+# Markdown Features
 
 Contented [unified](https://www.npmjs.com/package/unified) processor pipeline.
 

--- a/packages/contented-example/docs/09-Others/02-limitations.md
+++ b/packages/contented-example/docs/09-Others/02-limitations.md
@@ -1,6 +1,4 @@
----
-title: Known Limitations
----
+# Known Limitations
 
 ## Customization
 

--- a/packages/contented-example/docs/09-Others/99-contributing.md
+++ b/packages/contented-example/docs/09-Others/99-contributing.md
@@ -1,6 +1,4 @@
----
-title: Contributing Guidelines
----
+# Contributing Guidelines
 
 > Taken
 > from [BirthdayResearch/.github/CONTRIBUTING.md](https://github.com/BirthdayResearch/.github/edit/main/CONTRIBUTING.md)

--- a/packages/contented-example/docs/09-ballad.md
+++ b/packages/contented-example/docs/09-ballad.md
@@ -1,6 +1,4 @@
----
-title: Ballad of Engineering
----
+# Ballad of Engineering
 
 ```shell
 npm i

--- a/packages/contented-example/jest/Pipelines/JestMarkdown.spec.ts
+++ b/packages/contented-example/jest/Pipelines/JestMarkdown.spec.ts
@@ -1,9 +1,7 @@
 import { join } from 'node:path';
 
 /**
- * ---
- * title: Jest Markdown Pipeline
- * ---
+ * # Jest Markdown Pipeline
  *
  * "Nothing is better than documentation with examples. But nothing is worse than examples that
  * don't work because the code has changed since the documentation was written." - rustbook

--- a/packages/contented-preview/src/pages/[[...slug]].page.jsx
+++ b/packages/contented-preview/src/pages/[[...slug]].page.jsx
@@ -85,7 +85,6 @@ export default function SlugPage({ content, sections }) {
         >
           <article>
             <ContentProse>
-              {content.fields.title && <h1>{content.fields.title}</h1>}
               <div dangerouslySetInnerHTML={{ __html: content.html + `<!--${theme}-->` }} />
             </ContentProse>
           </article>


### PR DESCRIPTION
#### What this PR does / why we need it:

The title should be part of the docs as a heading, this is a breaking change.

```diff
---
- title: Title
description: Describing
---

+ # Title

Your content.
```